### PR TITLE
accept single column strings as parameter for cache_factor()

### DIFF
--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -51,6 +51,9 @@ class ctable(bcolz.ctable):
             raise TypeError('Only out-of-core ctables can have '
                             'factorization caching at the moment')
 
+        if not isinstance(col_list, list):
+            col_list = [col_list]
+
         for col in col_list:
 
             # create cache if needed


### PR DESCRIPTION
allow calling `cache_factor()` with:
```
cache_factor('my_col')
```
instead of forcing user to use:
```
cache_factor(['my_col'])
```
