### PR TITLE
Python 3 Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 #- 2.6
 - 2.7
 # TODO: should python 3.4 be supported?
-#- 3.4
+- 3.4
 install:
 - pip install --install-option='--no-cython-compile' cython
 - pip install numpy

--- a/bquery/__init__.py
+++ b/bquery/__init__.py
@@ -1,3 +1,3 @@
 from bquery.ctable import ctable
 from bquery.carray import carray
-from toplevel import open
+from bquery.toplevel import open

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -1,5 +1,5 @@
 # internal imports
-import ctable_ext
+from bquery import ctable_ext
 
 # external imports
 import numpy as np

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -70,7 +70,7 @@ class ctable(bcolz.ctable):
                 carray_factor.flush()
 
                 carray_values = \
-                    bcolz.carray(values.values(), dtype=self[col].dtype,
+                    bcolz.carray(np.fromiter(values.values(), dtype=self[col].dtype),
                                  rootdir=col_values_rootdir, mode='w')
                 carray_values.flush()
 
@@ -240,7 +240,7 @@ class ctable(bcolz.ctable):
             else:
                 col_factor_carray, values = ctable_ext.factorize(self[col])
                 col_values_carray = \
-                    bcolz.carray(values.values(), dtype=self[col].dtype)
+                    bcolz.carray(np.fromiter(values.values(), dtype=self[col].dtype))
 
             factor_list.append(col_factor_carray)
             values_list.append(col_values_carray)
@@ -299,7 +299,7 @@ class ctable(bcolz.ctable):
             # values might contain one value too much (-1) (no direct lookup
             # possible because values is a reversed dict)
             filter_check = \
-                [key for key, value in values.iteritems() if value == -1]
+                [key for key, value in values.items() if value == -1]
             if filter_check:
                 skip_key = filter_check[0]
 

--- a/bquery/templates/ctable_ext.template.pyx
+++ b/bquery/templates/ctable_ext.template.pyx
@@ -6,7 +6,12 @@ import cython
 import bcolz as bz
 from bcolz.carray_ext cimport carray, chunk
 
-import itertools as itt
+try:
+    # Python 2
+    from itertools import izip
+except ImportError:
+    # Python 3
+    izip = zip
 
 from libc.stdlib cimport malloc
 from libc.string cimport strcpy
@@ -664,7 +669,7 @@ cpdef is_in_ordered_subgroups(carray groups_col, carray bool_arr=None,
     x_ones = np.ones(max_len_subgroup, dtype='bool')
     x_zeros = np.zeros(max_len_subgroup, dtype='bool')
 
-    for bl_basket, bl_bool_arr in itt.izip(
+    for bl_basket, bl_bool_arr in izip(
             bz.iterblocks(groups_col, blen=blen),
             bz.iterblocks(bool_arr, blen=blen)):
 

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -22,7 +22,7 @@ class TestCtable():
         self.rootdir = tempfile.mkdtemp(prefix='bcolz-')
         os.rmdir(self.rootdir)  # folder should be emtpy
         ct = bquery.ctable(data, rootdir=self.rootdir)
-        # print ct
+        # print(ct)
         ct.flush()
         ct = bquery.open(self.rootdir)
 
@@ -33,11 +33,11 @@ class TestCtable():
 
 
     def setup(self):
-        print 'TestCtable.setup'
+        print('TestCtable.setup')
         self.rootdir = None
 
     def teardown(self):
-        print 'TestCtable.teardown'
+        print('TestCtable.teardown')
         if self.rootdir:
             shutil.rmtree(self.rootdir)
             self.rootdir = None
@@ -144,13 +144,13 @@ class TestCtable():
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         assert_list_equal(list(result_bcolz['f0']), uniquekeys)
 
@@ -180,13 +180,13 @@ class TestCtable():
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         assert_list_equal(
             sorted([list(x) for x in result_bcolz[groupby_cols]]),
@@ -218,13 +218,13 @@ class TestCtable():
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
         for item in result_itt['groups']:
@@ -268,13 +268,13 @@ class TestCtable():
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
         for item in result_itt['groups']:
@@ -327,13 +327,13 @@ class TestCtable():
             fact_bcolz.flush()
 
             result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
-            print result_bcolz
+            print(result_bcolz)
 
             # Itertools result
             print('--> Itertools')
             result_itt = self.helper_itt_groupby(data, groupby_lambda)
             uniquekeys = result_itt['uniquekeys']
-            print uniquekeys
+            print(uniquekeys)
 
             ref = []
             for item in result_itt['groups']:
@@ -374,13 +374,13 @@ class TestCtable():
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
                                           agg_method='count')
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
         for item in result_itt['groups']:
@@ -422,13 +422,13 @@ class TestCtable():
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
                                           agg_method='count_na')
-        print result_bcolz
+        print(result_bcolz)
 
         # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
         for item in result_itt['groups']:
@@ -501,8 +501,8 @@ class TestCtable():
         # -- Data --
         g = self.gen_dataset_count_with_NA_08(num_rows)
         data = np.fromiter(g, dtype='S1,f8,i8,i4,f8,i8,i4')
-        print 'data'
-        print data
+        print('data')
+        print(data)
 
         # -- Bcolz --
         print('--> Bcolz')
@@ -514,13 +514,13 @@ class TestCtable():
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
                                           agg_method='count_distinct')
-        print result_bcolz
+        print(result_bcolz)
         #
         # # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
 
@@ -569,8 +569,8 @@ class TestCtable():
         # -- Data --
         g = self.gen_dataset_count_with_NA_09(num_rows)
         data = np.fromiter(g, dtype='S1,f8,i8,i4,f8,i8,i4')
-        print 'data'
-        print data
+        print('data')
+        print(data)
 
         # -- Bcolz --
         print('--> Bcolz')
@@ -581,13 +581,13 @@ class TestCtable():
 
         result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
                                           agg_method='sorted_count_distinct')
-        print result_bcolz
+        print(result_bcolz)
 
         # # Itertools result
         print('--> Itertools')
         result_itt = self.helper_itt_groupby(data, groupby_lambda)
         uniquekeys = result_itt['uniquekeys']
-        print uniquekeys
+        print(uniquekeys)
 
         ref = []
 
@@ -596,7 +596,7 @@ class TestCtable():
             f5 = len(self._get_unique([x[5] for x in result_itt['groups'][n]]))
             f6 = len(self._get_unique([x[6] for x in result_itt['groups'][n]]))
             ref.append([u, f4, f5, f6])
-        print ref
+        print(ref)
 
         assert_list_equal(
             [list(x) for x in result_bcolz], ref)

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -53,10 +53,10 @@ class TestCtable():
         pool_d = itertools.cycle([0,0,1,1,1,3,3,3,3,3])
         for _ in range(N):
             d = (
-                pool.next(),
-                pool_b.next(),
-                pool_c.next(),
-                pool_d.next(),
+                next(pool),
+                next(pool_b),
+                next(pool_c),
+                next(pool_d),
                 random.random(),
                 random.randint(- 10, 10),
                 random.randint(- 10, 10),
@@ -77,11 +77,11 @@ class TestCtable():
                                   np.nan,3.0,3.0,3.0,3.0])
         for _ in range(N):
             d = (
-                pool.next(),
-                pool_b.next(),
-                pool_c.next(),
-                pool_d.next(),
-                pool_e.next(),
+                next(pool),
+                next(pool_b),
+                next(pool_c),
+                next(pool_d),
+                next(pool_e),
                 random.randint(- 10, 10),
                 random.randint(- 10, 10),
             )
@@ -94,10 +94,10 @@ class TestCtable():
         pool_d = itertools.cycle([1, 2, 3])
         for _ in range(N):
             d = (
-                pool.next(),
-                pool_b.next(),
-                pool_c.next(),
-                pool_d.next(),
+                next(pool),
+                next(pool_b),
+                next(pool_c),
+                next(pool_d),
                 random.random(),
                 random.randint(- 10, 10),
                 random.randint(- 10, 10),
@@ -477,11 +477,11 @@ class TestCtable():
                                   np.nan, 3.0, 1.0, 3.0, 1.0])
         for _ in range(N):
             d = (
-                pool.next(),
-                pool_b.next(),
-                pool_c.next(),
-                pool_d.next(),
-                pool_e.next(),
+                next(pool),
+                next(pool_b),
+                next(pool_c),
+                next(pool_d),
+                next(pool_e),
                 random.randint(- 500, 500),
                 random.randint(- 100, 100),
             )
@@ -544,14 +544,14 @@ class TestCtable():
         pool_g = (math.ceil(x) for x in np.arange(0, N, 1))
         for _ in range(N):
             d = (
-                pool.next(),
-                pool_b.next(),
-                pool_c.next(),
-                pool_d.next(),
+                next(pool),
+                next(pool_b),
+                next(pool_c),
+                next(pool_d),
                 # --
-                pool_e.next(),
-                pool_f.next(),
-                pool_g.next(),
+                next(pool_e),
+                next(pool_f),
+                next(pool_g),
             )
             yield d
 

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -489,7 +489,7 @@ class TestCtable():
 
     def test_groupby_08(self):
         """
-        test_groupby_08: Groupby's type 'sorted_count_distinct'
+        test_groupby_08: Groupby's type 'count_distinct'
         """
         random.seed(1)
 
@@ -557,7 +557,7 @@ class TestCtable():
 
     def test_groupby_09(self):
         """
-        test_groupby_08: Groupby's type 'sorted_count_distinct'
+        test_groupby_09: Groupby's type 'sorted_count_distinct'
         """
         random.seed(1)
 

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -568,7 +568,8 @@ class TestCtable():
 
         # -- Data --
         g = self.gen_dataset_count_with_NA_09(num_rows)
-        data = np.fromiter(g, dtype='S1,f8,i8,i4,f8,i8,i4')
+        sort = sorted([item for item in g], key=lambda x: x[0])
+        data = np.fromiter(sort, dtype='S1,f8,i8,i4,f8,i8,i4')
         print('data')
         print(data)
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ class bquery_build_ext(build_ext):
                 exit_with_error(
                     "You need the python package jinja2 to rebuild the " + \
                     "extension from the templates")
-            execfile("bquery/templates/run_templates.py")
+            exec(open("bquery/templates/run_templates.py").read())
 
         build_ext.run(self)
 


### PR DESCRIPTION
Enable use of bquery with Python 3, while maintaining compatibility with 2.7