### PR TITLE
Correct agg ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ ctable.groupby(list of groupby columns, agg_list)
 
 The agg_list contains the aggregations operations, which can be:
 - a straight forward sum of a list of columns with a similarly named output: ['m1', 'm2', ...]
-- a list of new columns with input/output names [['mnew1', 'm1'], ['mnew2', 'm2], ...]
-- a list that includes the type of aggregation for each column, i.e. [['mnew1', 'm1', 'sum'], ['mnew2', 'm1, 'avg'], ...]
+- a list of new columns with input names & aggregations [['m1', 'sum'], ['m2', 'count'], ...]
+- a list that includes the type of aggregation and the output of each column, i.e. [['m1', 'sum', 'm1_sum'], ['m1', 'count', 'm1_count'], ...]
 
 Examples:
 
     # groupby column f0, perform a sum on column f2 and keep the output column with the same name
     ct.groupby(['f0'], ['f2'])
 
-    # groupby column f0, perform a sum on column f2 and rename the output column to f2_sum
-    ct.groupby(['f0'], [['f2', 'f2_sum']])
+    # groupby column f0, perform a count on column f2
+    ct.groupby(['f0'], [['f2', 'count']])
 
-    # groupby column f0, with a sum on f2 ('f2_sum') and a sum_na on f2 ('f2_sum_na')
-    ct.groupby(['f0'], [['f2', 'f2_sum', 'sum'], ['f2', 'f2_sum_na', 'sum_na']])
+    # groupby column f0, with a sum on f2 (output to 'f2_sum') and a sum_na on f2 (output to 'f2_sum_na')
+    ct.groupby(['f0'], [['f2', 'sum', 'f2_sum'], ['f2', 'sum_na', 'f2_sum_na']])
 
 If recurrent aggregations are done (typical in a reporting environment), you can speed up aggregations by preparing factorizations of groupby columns:
 

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -4,7 +4,7 @@ from bquery import ctable_ext
 # external imports
 import numpy as np
 import bcolz
-import gc
+import tempfile
 import os
 from bquery.ctable_ext import \
     SUM, COUNT, COUNT_NA, COUNT_DISTINCT, SORTED_COUNT_DISTINCT
@@ -112,59 +112,59 @@ class ctable(bcolz.ctable):
 
     def aggregate_groups(self, ct_agg, nr_groups, skip_key,
                                    factor_carray, groupby_cols, output_agg_ops,
-                                   bool_arr=None,
-                                   agg_method=ctable_ext.SUM):
+                                   dtype_dict, bool_arr=None):
         '''Perform aggregation and place the result in the given ctable.
 
         Args:
             ct_agg (ctable): the table to hold the aggregation
             nr_groups (int): the number of groups (number of rows in output table)
-            skip_key (int): index of the output row to remove from results
-            factor_carray:
-            groupby_cols:
+            skip_key (int): index of the output row to remove from results (used for filtering)
+            factor_carray: the carray for each row in the table a reference to the the unique group index
+            groupby_cols: the list of 'dimension' columns that are used to perform the groupby over
             output_agg_ops (list): list of tuples of the form: (input_col, agg_op)
                     input_col (string): name of the column to act on
                     agg_op (int): aggregation operation to perform
-            bool_arr:
-            agg_method (int): the type of aggregation to perform
+            bool_arr: a boolean array containing the filter
 
         '''
-        total = []
 
+        # this creates the groupby columns
         for col in groupby_cols:
-            total.append(ctable_ext.groupby_value(self[col], factor_carray,
-                                                  nr_groups, skip_key))
+            result_array = ctable_ext.groupby_value(self[col], factor_carray,
+                                                  nr_groups, skip_key)
 
-        for col, agg_op in output_agg_ops:
-            # TODO: input vs output column
-            input_col_dtype = ct_agg[col].dtype
+            if bool_arr is not None:
+                result_array = np.delete(result_array, skip_key)
 
-            if input_col_dtype == np.float64:
-                r = ctable_ext.sum_float64(self[col], factor_carray, nr_groups,
-                                           skip_key, agg_method=agg_method)
-            elif input_col_dtype == np.int64:
-                r = ctable_ext.sum_int64(self[col], factor_carray, nr_groups,
-                                         skip_key, agg_method=agg_method)
-            elif input_col_dtype == np.int32:
-                r = ctable_ext.sum_int32(self[col], factor_carray, nr_groups,
-                                         skip_key, agg_method=agg_method)
+            ct_agg.addcol(result_array, name=col)
+            del result_array
+
+        # this creates the aggregation columns
+        for input_col, output_col, agg_op in output_agg_ops:
+
+            col_dtype = dtype_dict[output_col]
+
+            if col_dtype == np.float64:
+                result_array = ctable_ext.agg_float64(self[input_col], factor_carray, nr_groups,
+                                           skip_key, agg_method=agg_op)
+            elif col_dtype == np.int64:
+                result_array = ctable_ext.agg_int64(self[input_col], factor_carray, nr_groups,
+                                         skip_key, agg_method=agg_op)
+            elif col_dtype == np.int32:
+                result_array = ctable_ext.agg_int32(self[input_col], factor_carray, nr_groups,
+                                         skip_key, agg_method=agg_op)
             else:
                 raise NotImplementedError(
                     'Column dtype ({0}) not supported for aggregation yet '
                     '(only int32, int64 & float64)'.format(str(input_col_dtype)))
 
-            total.append(r)
+            if bool_arr is not None:
+                result_array = np.delete(result_array, skip_key)
 
-        # TODO: fix ugly fix?
-        if bool_arr is not None:
-            total_v2 = []
-            for a in total:
-                total_v2.append(
-                    [item for (n, item) in enumerate(a) if n != skip_key])
-            total = total_v2
-        # end of fix
+            ct_agg.addcol(result_array, name=output_col)
+            del result_array
 
-        ct_agg.append(total)
+        ct_agg.delcol('tmp_col_bquery__')
 
     def groupby(self, groupby_cols, agg_list, bool_arr=None, rootdir=None,
                 agg_method='sum'):
@@ -198,15 +198,6 @@ class ctable(bcolz.ctable):
                           previously presorted
 
         """
-        # TODO: change aggregation types to method as described in "a list with the type of aggregation for each column"
-        map_agg_method = {
-            'sum': SUM,
-            'count': COUNT,
-            'count_na': COUNT_NA,
-            'count_distinct': COUNT_DISTINCT,
-            'sorted_count_distinct': SORTED_COUNT_DISTINCT,
-        }
-        _agg_method = map_agg_method[agg_method]
 
         if not agg_list:
             raise AttributeError('One or more aggregation operations '
@@ -218,15 +209,14 @@ class ctable(bcolz.ctable):
             self.make_group_index(factor_list, values_list, groupby_cols,
                                   len(self), bool_arr)
 
-        ct_agg, dtype_list, agg_ops = \
+        ct_agg, dtype_dict, agg_ops = \
             self.create_agg_ctable(groupby_cols, agg_list, nr_groups, rootdir)
 
         # perform aggregation
         self.aggregate_groups(ct_agg, nr_groups, skip_key,
                                         factor_carray, groupby_cols,
-                                        agg_ops,
-                                        bool_arr=bool_arr,
-                                        agg_method=_agg_method)
+                                        agg_ops, dtype_dict,
+                                        bool_arr=bool_arr)
 
         return ct_agg
 
@@ -425,17 +415,19 @@ class ctable(bcolz.ctable):
                     input_col (string): name of the column to act on
                     agg_op (int): aggregation operation to perform
         '''
-        dtype_list = []
+        dtype_dict = {}
 
         # include all the input columns
         for col in groupby_cols:
-            dtype_list.append((col, self[col].dtype))
+            dtype_dict[col] = self[col].dtype
 
-        agg_cols = []
         agg_ops = []
         op_translation = {
-            'sum': 1,
-            'sum_na': 2
+            'sum': SUM,
+            'count': COUNT,
+            'count_na': COUNT_NA,
+            'count_distinct': COUNT_DISTINCT,
+            'sorted_count_distinct': SORTED_COUNT_DISTINCT,
         }
 
         for agg_info in agg_list:
@@ -444,38 +436,37 @@ class ctable(bcolz.ctable):
                 # straight forward sum (a ['m1', 'm2', ...] parameter)
                 output_col = agg_info
                 input_col = agg_info
-                agg_op = 1
+                agg_op = SUM
             else:
                 # input/output settings [['mnew1', 'm1'], ['mnew2', 'm2], ...]
                 output_col = agg_info[0]
                 input_col = agg_info[1]
                 if len(agg_info) == 2:
-                    agg_op = 1
+                    agg_op = SUM
                 else:
                     # input/output settings [['mnew1', 'm1', 'sum'], ['mnew2', 'm1, 'avg'], ...]
-                    agg_op = agg_info[2]
-                    if agg_op not in op_translation:
+                    agg_op_input = agg_info[2]
+                    if agg_op_input not in op_translation:
                         raise NotImplementedError(
-                            'Unknown Aggregation Type: ' + unicode(agg_op))
-                    agg_op = op_translation[agg_op]
+                            'Unknown Aggregation Type: ' + unicode(agg_op_input))
+                    agg_op = op_translation[agg_op_input]
 
-            output_col_dtype = self[input_col].dtype
+            dtype_dict[output_col] = self[input_col].dtype
+
             # TODO: check if the aggregation columns is numeric
             # NB: we could build a concatenation for strings like pandas, but I would really prefer to see that as a
             # separate operation
 
             # save output
-            agg_cols.append(output_col)
-            agg_ops.append((input_col, agg_op))
-            dtype_list.append((output_col, output_col_dtype))
+            agg_ops.append((input_col, output_col, agg_op))
 
         # create aggregation table
         ct_agg = bcolz.ctable(
-            np.zeros(0, dtype_list),
+            np.zeros(expectedlen, [('tmp_col_bquery__', np.bool)]),
             expectedlen=expectedlen,
             rootdir=rootdir)
 
-        return ct_agg, dtype_list, agg_ops
+        return ct_agg, dtype_dict, agg_ops
 
     def where_terms(self, term_list):
         """

--- a/bquery/ctable_ext.pyx
+++ b/bquery/ctable_ext.pyx
@@ -602,7 +602,7 @@ cdef count_unique_int32(ndarray[int32_t] values):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef sum_float64(carray ca_input, carray ca_factor,
+cpdef agg_float64(carray ca_input, carray ca_factor,
                Py_ssize_t nr_groups, Py_ssize_t skip_key, agg_method=_SUM):
     cdef:
         chunk input_chunk, factor_chunk
@@ -755,7 +755,7 @@ cpdef sum_float64(carray ca_input, carray ca_factor,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef sum_int32(carray ca_input, carray ca_factor,
+cpdef agg_int32(carray ca_input, carray ca_factor,
                Py_ssize_t nr_groups, Py_ssize_t skip_key, agg_method=_SUM):
     cdef:
         chunk input_chunk, factor_chunk
@@ -906,7 +906,7 @@ cpdef sum_int32(carray ca_input, carray ca_factor,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef sum_int64(carray ca_input, carray ca_factor,
+cpdef agg_int64(carray ca_input, carray ca_factor,
                Py_ssize_t nr_groups, Py_ssize_t skip_key, agg_method=_SUM):
     cdef:
         chunk input_chunk, factor_chunk

--- a/bquery/templates/ctable_ext.template.pyx
+++ b/bquery/templates/ctable_ext.template.pyx
@@ -387,7 +387,7 @@ cdef count_unique_{{ count_unique_type }}(ndarray[{{ count_unique_type }}_t] val
 {% for sum_type in sum_types -%}
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef sum_{{ sum_type }}(carray ca_input, carray ca_factor,
+cpdef agg_{{ sum_type }}(carray ca_input, carray ca_factor,
                Py_ssize_t nr_groups, Py_ssize_t skip_key, agg_method=_SUM):
     cdef:
         chunk input_chunk, factor_chunk

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -218,8 +218,7 @@ class TestCtable():
         fact_bcolz.flush()
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                            agg_method='sum')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
 
         # Itertools result
@@ -270,8 +269,7 @@ class TestCtable():
         fact_bcolz.flush()
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                            agg_method='sum')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
 
         # Itertools result
@@ -331,8 +329,7 @@ class TestCtable():
             fact_bcolz = bquery.ctable(data, rootdir=self.rootdir)
             fact_bcolz.flush()
 
-            result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                                agg_method='sum')
+            result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
             print(result_bcolz)
 
             # Itertools result
@@ -363,7 +360,7 @@ class TestCtable():
 
         groupby_cols = ['f0']
         groupby_lambda = lambda x: x[0]
-        agg_list = ['f4', 'f5', 'f6']
+        agg_list = [['f4', 'count'], ['f5', 'count'], ['f6', 'count']]
         num_rows = 2000
 
         # -- Data --
@@ -378,8 +375,7 @@ class TestCtable():
         fact_bcolz.flush()
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                          agg_method='count')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
 
         # Itertools result
@@ -411,7 +407,7 @@ class TestCtable():
 
         groupby_cols = ['f0']
         groupby_lambda = lambda x: x[0]
-        agg_list = ['f4', 'f5', 'f6']
+        agg_list = [['f4', 'count_na'], ['f5', 'count_na'], ['f6', 'count_na']]
         num_rows = 1000
 
         # -- Data --
@@ -426,8 +422,7 @@ class TestCtable():
         fact_bcolz.flush()
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                          agg_method='count_na')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
 
         # Itertools result
@@ -501,7 +496,7 @@ class TestCtable():
 
         groupby_cols = ['f0']
         groupby_lambda = lambda x: x[0]
-        agg_list = ['f4', 'f5', 'f6']
+        agg_list = [['f4', 'count_distinct'], ['f5', 'count_distinct'], ['f6', 'count_distinct']]
         num_rows = 2000
 
         # -- Data --
@@ -518,8 +513,7 @@ class TestCtable():
         fact_bcolz.flush()
 
         fact_bcolz.cache_factor(groupby_cols, refresh=True)
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                          agg_method='count_distinct')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
         #
         # # Itertools result
@@ -569,7 +563,7 @@ class TestCtable():
 
         groupby_cols = ['f0']
         groupby_lambda = lambda x: x[0]
-        agg_list = ['f4', 'f5', 'f6']
+        agg_list = [['f4', 'sorted_count_distinct'], ['f5', 'sorted_count_distinct'], ['f6', 'sorted_count_distinct']]
         num_rows = 1000
 
         # -- Data --
@@ -586,8 +580,7 @@ class TestCtable():
         fact_bcolz = bquery.ctable(data, rootdir=self.rootdir)
         fact_bcolz.flush()
 
-        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list,
-                                          agg_method='sorted_count_distinct')
+        result_bcolz = fact_bcolz.groupby(groupby_cols, agg_list)
         print(result_bcolz)
 
         # # Itertools result
@@ -615,7 +608,7 @@ class TestCtable():
         random.seed(1)
 
         groupby_cols = []
-        agg_list = ['f1', 'f2']
+        agg_list = [['f1', 'sorted_count_distinct'], ['f2', 'sorted_count_distinct']]
         num_rows = 10
 
         # -- Data --
@@ -634,8 +627,7 @@ class TestCtable():
 
         # -- Bcolz --
         with self.on_disk_data_cleaner(data) as ct:
-            result_bcolz = ct.groupby(groupby_cols, agg_list,
-                                      agg_method='sorted_count_distinct')
+            result_bcolz = ct.groupby(groupby_cols, agg_list)
 
         assert_list_equal([list(x) for x in result_bcolz], [[4, 2]])
 
@@ -649,7 +641,7 @@ class TestCtable():
         random.seed(1)
 
         groupby_cols = []
-        agg_list = ['f1', 'f2']
+        agg_list = [['f1', 'sorted_count_distinct'], ['f2', 'sorted_count_distinct']]
         num_rows = 10
 
         # -- Data --
@@ -669,8 +661,7 @@ class TestCtable():
         with self.on_disk_data_cleaner(data) as ct:
             barr = ct.where_terms( [('f0', 'in', [0])] )
             result_bcolz = ct.groupby(groupby_cols, agg_list,
-                                      bool_arr=barr,
-                                      agg_method='sorted_count_distinct')
+                                      bool_arr=barr)
 
         assert_list_equal([list(x) for x in result_bcolz], [[3, 2]])
 
@@ -681,7 +672,7 @@ class TestCtable():
         random.seed(1)
 
         groupby_cols = []
-        agg_list = ['f1']
+        agg_list = [['f1', 'sorted_count_distinct']]
         num_rows = 10
 
         # -- Data --
@@ -699,8 +690,7 @@ class TestCtable():
 
 
         with self.on_disk_data_cleaner(data) as ct:
-            result_bcolz = ct.groupby(groupby_cols, agg_list,
-                                      agg_method='sorted_count_distinct')
+            result_bcolz = ct.groupby(groupby_cols, agg_list)
 
         assert_list_equal([list(x) for x in result_bcolz], [[4]])
 
@@ -711,7 +701,7 @@ class TestCtable():
         random.seed(1)
 
         groupby_cols = ['f0']
-        agg_list = ['f1']
+        agg_list = [['f1', 'sorted_count_distinct']]
 
         # -- Data --
         data = np.array(
@@ -731,8 +721,7 @@ class TestCtable():
         with self.on_disk_data_cleaner(data) as ct:
             barr = ct.where_terms( [('f0', 'in', [0, 1])] )
             result_bcolz = ct.groupby(groupby_cols, agg_list,
-                                      bool_arr=barr,
-                                      agg_method='sorted_count_distinct')
+                                      bool_arr=barr)
 
         assert_list_equal([list(x) for x in result_bcolz], [[0, 3], [1, 3]])
 


### PR DESCRIPTION
An update that:

- greatly should improve memory usage for large (multi-billion) aggregations; it now directly compresses each individual groupby step
- massively improved the groupby call to actually do what the documentation states (reshuffled the order of calls to make it more logical and sql-like)
- prepares for multi-threading (groupby and aggregation column generation should be able to be combined now and then run parallel; for next version)
