### PR TITLE
Implement Mean and Standard Deviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The `agg_list` contains the aggregation operations, which can be:
 
 ### Supported Operations
 * `sum`
-* `mean`
+* `mean` arithmetic mean (average)
+* `std` standard deviation
 * `count`
 * `count_na`
 * `count_distinct`
@@ -85,10 +86,10 @@ export PYTHONPATH=$(pwd)/bcolz:${PYTHONPATH}
 
 Go back to your bquery directory and repeat build and install steps.
 
-```python setup.py build_ext --from-templates --inplace```.
+```python setup.py build_ext --inplace```.
 
 ```
-python setup.py build_ext --from-templates --inplace
+python setup.py build_ext --inplace
 python setup.py install
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,25 @@ Bquery subclasses the ctable from bcolz, meaning that all original ctable functi
 
 A groupby with aggregation is easy to perform:
 
-ctable.groupby(list of groupby columns, agg_list)
+    ctable.groupby(list_of_groupby_columns, agg_list)
 
-The agg_list contains the aggregations operations, which can be:
-- a straight forward sum of a list of columns with a similarly named output: ['m1', 'm2', ...]
-- a list of new columns with input names & aggregations [['m1', 'sum'], ['m2', 'count'], ...]
-- a list that includes the type of aggregation and the output of each column, i.e. [['m1', 'sum', 'm1_sum'], ['m1', 'count', 'm1_count'], ...]
+The `agg_list` contains the aggregation operations, which can be:
+* a straight forward list of columns (a sum is performed on each and stored in a column of the same name)
+    - `['m1', 'm2', ...]`
+- a list of lists where each list gives input column name and operation)
+    - `[['m1', 'sum'], ['m2', 'count'], ...]`
+- a list of lists where each list additionally includes an output column name
+    - `[['m1', 'sum', 'm1_sum'], ['m1', 'count', 'm1_count'], ...]`
 
-Examples:
+### Supported Operations
+* `sum`
+* `mean`
+* `count`
+* `count_na`
+* `count_distinct`
+* `sorted_count_distinct`
+
+### Examples
 
     # groupby column f0, perform a sum on column f2 and keep the output column with the same name
     ct.groupby(['f0'], ['f2'])
@@ -44,8 +55,9 @@ Examples:
     # groupby column f0, perform a count on column f2
     ct.groupby(['f0'], [['f2', 'count']])
 
-    # groupby column f0, with a sum on f2 (output to 'f2_sum') and a sum_na on f2 (output to 'f2_sum_na')
-    ct.groupby(['f0'], [['f2', 'sum', 'f2_sum'], ['f2', 'sum_na', 'f2_sum_na']])
+    # groupby column f0, with a sum on f2 (output to 'f2_sum') and a mean on f2 (output to 'f2_mean')
+    ct.groupby(['f0'], [['f2', 'sum', 'f2_sum'], ['f2', 'mean', 'f2_mean']])
+
 
 If recurrent aggregations are done (typical in a reporting environment), you can speed up aggregations by preparing factorizations of groupby columns:
 
@@ -72,12 +84,8 @@ export PYTHONPATH=$(pwd)/bcolz:${PYTHONPATH}
 ```
 
 Go back to your bquery directory and repeat build and install steps.
-Note: ```bquery/templates/ctable_ext.template.pyx``` will be used as 
-template to generate the source file ```bquery/ctable_ext.pyx``` used 
-by the cython compiler, if you are developing new features remember to write 
-those modifications in the template file, ```bquery/ctable_ext.pyx```
-will be overwritten each time you run 
-```python setup.py build_ext --from-templates --inplace```. 
+
+```python setup.py build_ext --from-templates --inplace```.
 
 ```
 python setup.py build_ext --from-templates --inplace

--- a/bquery/benchmarks/bench_groupby.py
+++ b/bquery/benchmarks/bench_groupby.py
@@ -16,6 +16,13 @@ import tempfile
 import os
 import time
 
+try:
+    # Python 2
+    from itertools import izip
+except ImportError:
+    # Python 3
+    izip = zip
+
 t_elapsed = 0.0
 @contextlib.contextmanager
 def ctime(message=None):
@@ -43,7 +50,7 @@ n_rows = 1000000
 print('Rows: ', n_rows)
 
 # -- data
-z = np.fromiter(((a, b, x, y) for a, b, x, y in itt.izip(ga, gb, gx, gy)),
+z = np.fromiter(((a, b, x, y) for a, b, x, y in izip(ga, gb, gx, gy)),
                 dtype='S2,S2,i8,i8', count=n_rows)
 
 ct = bquery.ctable(z, rootdir=rootdir, )

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -146,20 +146,23 @@ class ctable(bcolz.ctable):
             input_col = self[input_col_name]
             output_col_dtype = dtype_dict[output_col_name]
 
+            input_buffer = np.empty(input_col.chunklen, dtype=input_col.dtype)
+            output_buffer = np.zeros(nr_groups, dtype=output_col_dtype)
+
             try:
-                input_buffer = np.empty(input_col.chunklen, dtype=input_col.dtype)
-                result_array = ctable_ext.aggregate(input_col, factor_carray, nr_groups,
-                                           skip_key, input_buffer, agg_op)
+                ctable_ext.aggregate(input_col, factor_carray, nr_groups,
+                                           skip_key, input_buffer, output_buffer,
+                                           agg_op)
             except:
                 raise NotImplementedError(
                     'Column dtype ({0}) not supported for aggregation yet '
                     '(only int32, int64 & float64)'.format(str(input_col.dtype)))
 
             if bool_arr is not None:
-                result_array = np.delete(result_array, skip_key)
+                output_buffer = np.delete(output_buffer, skip_key)
 
-            ct_agg.addcol(result_array, name=output_col_name)
-            del result_array
+            ct_agg.addcol(output_buffer, name=output_col_name)
+            del output_buffer
 
         ct_agg.delcol('tmp_col_bquery__')
 

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -153,10 +153,12 @@ class ctable(bcolz.ctable):
                 ctable_ext.aggregate(input_col, factor_carray, nr_groups,
                                            skip_key, input_buffer, output_buffer,
                                            agg_op)
-            except:
+            except TypeError:
                 raise NotImplementedError(
                     'Column dtype ({0}) not supported for aggregation yet '
                     '(only int32, int64 & float64)'.format(str(input_col.dtype)))
+            except Exception as e:
+                raise e
 
             if bool_arr is not None:
                 output_buffer = np.delete(output_buffer, skip_key)
@@ -188,7 +190,8 @@ class ctable(bcolz.ctable):
             - 'count_distinct'
             - 'sorted_count_distinct', data should have been
                   previously presorted
-            - 'mean'
+            - 'mean', arithmetic mean (average)
+            - 'std', standard deviation
 
         boolarr: to be added (filtering the groupby factorization input)
         rootdir: the aggregation ctable rootdir
@@ -428,7 +431,8 @@ class ctable(bcolz.ctable):
             'count_na': COUNT_NA,
             'count_distinct': COUNT_DISTINCT,
             'sorted_count_distinct': SORTED_COUNT_DISTINCT,
-            'mean' : MEAN
+            'mean' : MEAN,
+            'std' : STDEV
         }
 
         for agg_info in agg_list:

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -175,7 +175,7 @@ class ctable(bcolz.ctable):
 
         groupby_cols: a list of columns to groupby over
         agg_list: the aggregation operations, which can be:
-         - a list columns names (output has same name and sum is performed)
+         - a list of column names (output has same name and sum is performed)
            ['m1', 'm2', ...]
          - a list of lists, each list contains input column name and operation
            [['m1', 'sum'], ['m2', 'mean'], ...]
@@ -195,9 +195,6 @@ class ctable(bcolz.ctable):
 
         boolarr: to be added (filtering the groupby factorization input)
         rootdir: the aggregation ctable rootdir
-
-        agg_method: Supported aggregation methods
-
         """
 
         if not agg_list:
@@ -413,9 +410,9 @@ class ctable(bcolz.ctable):
                     the specified aggregation operations.
             dict: (dtype_dict) dictionary describing columns to create
             list: (agg_ops) list of tuples of the form:
-                    (input_col, output_col, agg_op)
-                    input_col (string): name of the column to act on
-                    output_col (string): name of the column to output to
+                    (input_col_name, output_col_name, agg_op)
+                    input_col_name (string): name of the column to act on
+                    output_col_name (string): name of the column to output to
                     agg_op (int): aggregation operation to perform
         '''
         dtype_dict = {}

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -453,7 +453,6 @@ class ctable(bcolz.ctable):
                         'Unknown Aggregation Type: ' + unicode(agg_op_input))
                 agg_op = op_translation[agg_op_input]
 
-            dtype_dict[output_col] = self[input_col].dtype
 
             # choose output column dtype based on aggregation operation and
             # input column dtype
@@ -467,6 +466,7 @@ class ctable(bcolz.ctable):
             else:
                 output_col_dtype = self[input_col].dtype
 
+            dtype_dict[output_col] = output_col_dtype
 
             # save output
             agg_ops.append((input_col, output_col, agg_op))

--- a/bquery/ctable_ext.pyx
+++ b/bquery/ctable_ext.pyx
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy cimport ndarray, dtype, npy_intp, npy_int32, \
-    npy_uint64, npy_int64, npy_float64, npy_bool
+cimport numpy as np
 
 import cython
 import bcolz as bz
@@ -24,6 +23,12 @@ from khash cimport *
 SUM = 0
 DEF _SUM = 0
 
+MEAN = 5
+DEF _MEAN = 5
+
+STDEV = 6
+DEF _STDEV = 6
+
 COUNT = 1
 DEF _COUNT = 1
 
@@ -37,13 +42,31 @@ SORTED_COUNT_DISTINCT = 4
 DEF _SORTED_COUNT_DISTINCT = 4
 # ----------------------------------------------------------------------------
 
+# ----------------------------------------------------------------------------
+#                        FUSED TYPES
+# ----------------------------------------------------------------------------
+# fused types (templating) from
+# http://docs.cython.org/src/userguide/fusedtypes.html
+ctypedef fused numpy_native_number_input:
+    np.int64_t
+    np.int32_t
+    np.float64_t
+
+ctypedef fused numpy_native_number_output:
+    np.int64_t
+    np.int32_t
+    np.float64_t
+
+
+# ----------------------------------------------------------------------------
+
 # Factorize Section
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef void _factorize_str_helper(Py_ssize_t iter_range,
                        Py_ssize_t allocation_size,
-                       ndarray in_buffer,
-                       ndarray[npy_uint64] out_buffer,
+                       np.ndarray in_buffer,
+                       np.ndarray[np.uint64_t] out_buffer,
                        kh_str_t *table,
                        Py_ssize_t * count,
                        dict reverse,
@@ -82,8 +105,8 @@ def factorize_str(carray carray_, carray labels=None):
         chunk chunk_
         Py_ssize_t n, i, count, chunklen, leftover_elements
         dict reverse
-        ndarray in_buffer
-        ndarray[npy_uint64] out_buffer
+        np.ndarray in_buffer
+        np.ndarray[np.uint64_t] out_buffer
         kh_str_t *table
 
     count = 0
@@ -134,48 +157,95 @@ def factorize_str(carray carray_, carray labels=None):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef void _factorize_int64_helper(Py_ssize_t iter_range,
+cdef void _factorize_helper(Py_ssize_t iter_range,
                        Py_ssize_t allocation_size,
-                       ndarray[npy_int64] in_buffer,
-                       ndarray[npy_uint64] out_buffer,
-                       kh_int64_t *table,
+                       np.ndarray[numpy_native_number_input] in_buffer,
+                       np.ndarray[np.uint64_t] out_buffer,
+                       void *table,
                        Py_ssize_t * count,
                        dict reverse,
                        ):
+
     cdef:
         Py_ssize_t i, idx
         int ret
-        npy_int64 element
-        khiter_t k
+        numpy_native_number_input element
+        khiter_t
+        kh_int64_t *int64_table
+        kh_int32_t *int32_table
+        kh_float64_t *float64_table
 
     ret = 0
 
-    for i in range(iter_range):
-        # TODO: Consider indexing directly into the array for efficiency
-        element = in_buffer[i]
-        k = kh_get_int64(table, element)
-        if k != table.n_buckets:
-            idx = table.vals[k]
-        else:
-            k = kh_put_int64(table, element, &ret)
-            table.vals[k] = idx = count[0]
-            reverse[count[0]] = element
-            count[0] += 1
-        out_buffer[i] = idx
+    # Only one of these branches should be compiled for each specialization
+    if numpy_native_number_input is np.int64_t:
+        int64_table = <kh_int64_t*> table
+
+        for i in range(iter_range):
+            # TODO: Consider indexing directly into the array for efficiency
+            element = in_buffer[i]
+            k = kh_get_int64(int64_table, element)
+            if k != int64_table.n_buckets:
+                idx = int64_table.vals[k]
+            else:
+                k = kh_put_int64(int64_table, element, &ret)
+                int64_table.vals[k] = idx = count[0]
+                reverse[count[0]] = element
+                count[0] += 1
+            out_buffer[i] = idx
+
+    elif numpy_native_number_input is np.int32_t:
+        int32_table = <kh_int32_t*> table
+
+        for i in range(iter_range):
+            # TODO: Consider indexing directly into the array for efficiency
+            element = in_buffer[i]
+            k = kh_get_int32(int32_table, element)
+            if k != int32_table.n_buckets:
+                idx = int32_table.vals[k]
+            else:
+                k = kh_put_int32(int32_table, element, &ret)
+                int32_table.vals[k] = idx = count[0]
+                reverse[count[0]] = element
+                count[0] += 1
+            out_buffer[i] = idx
+
+    elif numpy_native_number_input is np.float64_t:
+        float64_table = <kh_float64_t*> table
+
+        for i in range(iter_range):
+            # TODO: Consider indexing directly into the array for efficiency
+            element = in_buffer[i]
+            k = kh_get_float64(float64_table, element)
+            if k != float64_table.n_buckets:
+                idx = float64_table.vals[k]
+            else:
+                k = kh_put_float64(float64_table, element, &ret)
+                float64_table.vals[k] = idx = count[0]
+                reverse[count[0]] = element
+                count[0] += 1
+            out_buffer[i] = idx
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def factorize_int64(carray carray_, carray labels=None):
+cdef factorize_number(carray carray_,  numpy_native_number_input typehint, carray labels=None):
+    # fused type conversion
+    if numpy_native_number_input is np.int64_t:
+        p_dtype = np.int64
+    elif numpy_native_number_input is np.int32_t:
+        p_dtype = np.int32
+    elif numpy_native_number_input is np.float64_t:
+        p_dtype = np.float64
+
     cdef:
         chunk chunk_
         Py_ssize_t n, i, count, chunklen, leftover_elements
         dict reverse
-        ndarray[npy_int64] in_buffer
-        ndarray[npy_uint64] out_buffer
-        kh_int64_t *table
+        np.ndarray[numpy_native_number_input] in_buffer
+        np.ndarray[np.uint64_t] out_buffer
+        void *table
 
     count = 0
-    ret = 0
     reverse = {}
 
     n = len(carray_)
@@ -184,18 +254,27 @@ def factorize_int64(carray carray_, carray labels=None):
         labels = carray([], dtype='int64', expectedlen=n)
     # in-buffer isn't typed, because cython doesn't support string arrays (?)
     out_buffer = np.empty(chunklen, dtype='uint64')
-    in_buffer = np.empty(chunklen, dtype='int64')
-    table = kh_init_int64()
+    in_buffer = np.empty(chunklen, dtype=p_dtype)
+
+    if numpy_native_number_input is np.int64_t:
+        table = kh_init_int64()
+    elif numpy_native_number_input is np.int32_t:
+        table = kh_init_int32()
+    elif numpy_native_number_input is np.float64_t:
+        table = kh_init_float64()
+    else:
+        table = kh_init_int64()
+
 
     for i in range(carray_.nchunks):
         chunk_ = carray_.chunks[i]
         # decompress into in_buffer
         chunk_._getitem(0, chunklen, in_buffer.data)
-        _factorize_int64_helper(chunklen,
+        _factorize_helper[numpy_native_number_input](chunklen,
                         carray_.dtype.itemsize + 1,
                         in_buffer,
                         out_buffer,
-                        table,
+                        <void*> table,
                         &count,
                         reverse,
                         )
@@ -204,7 +283,7 @@ def factorize_int64(carray carray_, carray labels=None):
 
     leftover_elements = cython.cdiv(carray_.leftover, carray_.atomsize)
     if leftover_elements > 0:
-        _factorize_int64_helper(leftover_elements,
+        _factorize_helper[numpy_native_number_input](leftover_elements,
                           carray_.dtype.itemsize + 1,
                           carray_.leftover_array,
                           out_buffer,
@@ -216,193 +295,27 @@ def factorize_int64(carray carray_, carray labels=None):
     # compress out_buffer into labels
     labels.append(out_buffer[:leftover_elements].astype(np.int64))
 
-    kh_destroy_int64(table)
-
-    return labels, reverse
-
-@cython.wraparound(False)
-@cython.boundscheck(False)
-cdef void _factorize_int32_helper(Py_ssize_t iter_range,
-                       Py_ssize_t allocation_size,
-                       ndarray[npy_int32] in_buffer,
-                       ndarray[npy_uint64] out_buffer,
-                       kh_int32_t *table,
-                       Py_ssize_t * count,
-                       dict reverse,
-                       ):
-    cdef:
-        Py_ssize_t i, idx
-        int ret
-        npy_int32 element
-        khiter_t k
-
-    ret = 0
-
-    for i in range(iter_range):
-        # TODO: Consider indexing directly into the array for efficiency
-        element = in_buffer[i]
-        k = kh_get_int32(table, element)
-        if k != table.n_buckets:
-            idx = table.vals[k]
-        else:
-            k = kh_put_int32(table, element, &ret)
-            table.vals[k] = idx = count[0]
-            reverse[count[0]] = element
-            count[0] += 1
-        out_buffer[i] = idx
-
-@cython.wraparound(False)
-@cython.boundscheck(False)
-def factorize_int32(carray carray_, carray labels=None):
-    cdef:
-        chunk chunk_
-        Py_ssize_t n, i, count, chunklen, leftover_elements
-        dict reverse
-        ndarray[npy_int32] in_buffer
-        ndarray[npy_uint64] out_buffer
-        kh_int32_t *table
-
-    count = 0
-    ret = 0
-    reverse = {}
-
-    n = len(carray_)
-    chunklen = carray_.chunklen
-    if labels is None:
-        labels = carray([], dtype='int64', expectedlen=n)
-    # in-buffer isn't typed, because cython doesn't support string arrays (?)
-    out_buffer = np.empty(chunklen, dtype='uint64')
-    in_buffer = np.empty(chunklen, dtype='int32')
-    table = kh_init_int32()
-
-    for i in range(carray_.nchunks):
-        chunk_ = carray_.chunks[i]
-        # decompress into in_buffer
-        chunk_._getitem(0, chunklen, in_buffer.data)
-        _factorize_int32_helper(chunklen,
-                        carray_.dtype.itemsize + 1,
-                        in_buffer,
-                        out_buffer,
-                        table,
-                        &count,
-                        reverse,
-                        )
-        # compress out_buffer into labels
-        labels.append(out_buffer.astype(np.int64))
-
-    leftover_elements = cython.cdiv(carray_.leftover, carray_.atomsize)
-    if leftover_elements > 0:
-        _factorize_int32_helper(leftover_elements,
-                          carray_.dtype.itemsize + 1,
-                          carray_.leftover_array,
-                          out_buffer,
-                          table,
-                          &count,
-                          reverse,
-                          )
-
-    # compress out_buffer into labels
-    labels.append(out_buffer[:leftover_elements].astype(np.int64))
-
-    kh_destroy_int32(table)
-
-    return labels, reverse
-
-@cython.wraparound(False)
-@cython.boundscheck(False)
-cdef void _factorize_float64_helper(Py_ssize_t iter_range,
-                       Py_ssize_t allocation_size,
-                       ndarray[npy_float64] in_buffer,
-                       ndarray[npy_uint64] out_buffer,
-                       kh_float64_t *table,
-                       Py_ssize_t * count,
-                       dict reverse,
-                       ):
-    cdef:
-        Py_ssize_t i, idx
-        int ret
-        npy_float64 element
-        khiter_t k
-
-    ret = 0
-
-    for i in range(iter_range):
-        # TODO: Consider indexing directly into the array for efficiency
-        element = in_buffer[i]
-        k = kh_get_float64(table, element)
-        if k != table.n_buckets:
-            idx = table.vals[k]
-        else:
-            k = kh_put_float64(table, element, &ret)
-            table.vals[k] = idx = count[0]
-            reverse[count[0]] = element
-            count[0] += 1
-        out_buffer[i] = idx
-
-@cython.wraparound(False)
-@cython.boundscheck(False)
-def factorize_float64(carray carray_, carray labels=None):
-    cdef:
-        chunk chunk_
-        Py_ssize_t n, i, count, chunklen, leftover_elements
-        dict reverse
-        ndarray[npy_float64] in_buffer
-        ndarray[npy_uint64] out_buffer
-        kh_float64_t *table
-
-    count = 0
-    ret = 0
-    reverse = {}
-
-    n = len(carray_)
-    chunklen = carray_.chunklen
-    if labels is None:
-        labels = carray([], dtype='int64', expectedlen=n)
-    # in-buffer isn't typed, because cython doesn't support string arrays (?)
-    out_buffer = np.empty(chunklen, dtype='uint64')
-    in_buffer = np.empty(chunklen, dtype='float64')
-    table = kh_init_float64()
-
-    for i in range(carray_.nchunks):
-        chunk_ = carray_.chunks[i]
-        # decompress into in_buffer
-        chunk_._getitem(0, chunklen, in_buffer.data)
-        _factorize_float64_helper(chunklen,
-                        carray_.dtype.itemsize + 1,
-                        in_buffer,
-                        out_buffer,
-                        table,
-                        &count,
-                        reverse,
-                        )
-        # compress out_buffer into labels
-        labels.append(out_buffer.astype(np.int64))
-
-    leftover_elements = cython.cdiv(carray_.leftover, carray_.atomsize)
-    if leftover_elements > 0:
-        _factorize_float64_helper(leftover_elements,
-                          carray_.dtype.itemsize + 1,
-                          carray_.leftover_array,
-                          out_buffer,
-                          table,
-                          &count,
-                          reverse,
-                          )
-
-    # compress out_buffer into labels
-    labels.append(out_buffer[:leftover_elements].astype(np.int64))
-
-    kh_destroy_float64(table)
+    if numpy_native_number_input is np.int64_t:
+        kh_destroy_int64(<kh_int64_t*>table)
+    elif numpy_native_number_input is np.int32_t:
+        kh_destroy_int32(<kh_int32_t*>table)
+    elif numpy_native_number_input is np.float64_t:
+        kh_destroy_float64(<kh_float64_t*>table)
 
     return labels, reverse
 
 cpdef factorize(carray carray_, carray labels=None):
+    cdef:
+        np.int64_t hint64 = 0
+        np.int32_t hint32 = 0
+        np.float64_t hfloat64 = 0
+
     if carray_.dtype == 'int32':
-        labels, reverse = factorize_int32(carray_, labels=labels)
+        labels, reverse = factorize_number(carray_, hint32, labels=labels)
     elif carray_.dtype == 'int64':
-        labels, reverse = factorize_int64(carray_, labels=labels)
+        labels, reverse = factorize_number(carray_, hint64, labels=labels)
     elif carray_.dtype == 'float64':
-        labels, reverse = factorize_float64(carray_, labels=labels)
+        labels, reverse = factorize_number(carray_, hfloat64, labels=labels)
     else:
         #TODO: check that the input is a string_ dtype type
         labels, reverse = factorize_str(carray_, labels=labels)
@@ -412,12 +325,12 @@ cpdef factorize(carray carray_, carray labels=None):
 # Translate existing arrays
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef translate_int64(carray input_, carray output_, dict lookup, npy_int64 default=-1):
+cpdef translate_int64(carray input_, carray output_, dict lookup, np.int64_t default=-1):
     cdef:
         chunk chunk_
         Py_ssize_t i, chunklen, leftover_elements
-        ndarray[npy_int64] in_buffer
-        ndarray[npy_int64] out_buffer
+        np.ndarray[np.int64_t] in_buffer
+        np.ndarray[np.int64_t] out_buffer
 
     chunklen = input_.chunklen
     out_buffer = np.empty(chunklen, dtype='int64')
@@ -447,7 +360,7 @@ cpdef translate_int64(carray input_, carray output_, dict lookup, npy_int64 defa
 @cython.wraparound(False)
 def agg_sum_na(iter_):
     cdef:
-        npy_float64 v, v_cum = 0.0
+        np.float64_t v, v_cum = 0.0
 
     for v in iter_:
         if v == v:  # skip NA values
@@ -459,7 +372,7 @@ def agg_sum_na(iter_):
 @cython.wraparound(False)
 def agg_sum(iter_):
     cdef:
-        npy_float64 v, v_cum = 0.0
+        np.float64_t v, v_cum = 0.0
 
     for v in iter_:
         v_cum += v
@@ -473,13 +386,13 @@ def agg_sum(iter_):
 def groupsort_indexer(carray index, Py_ssize_t ngroups):
     cdef:
         Py_ssize_t i, label, n
-        ndarray[int64_t] counts, where, np_result
+        np.ndarray[int64_t] counts, where, np_result
         # --
         carray c_result
         chunk input_chunk, index_chunk
         Py_ssize_t index_chunk_nr, index_chunk_len, leftover_elements
 
-        ndarray[int64_t] in_buffer
+        np.ndarray[int64_t] in_buffer
 
     index_chunk_len = index.chunklen
     in_buffer = np.empty(index_chunk_len, dtype='int64')
@@ -521,14 +434,14 @@ def groupsort_indexer(carray index, Py_ssize_t ngroups):
 
     return np_result, counts
 
-cdef count_unique_float64(ndarray[float64_t] values):
+cdef count_unique_float64(np.ndarray[float64_t] values):
     cdef:
         Py_ssize_t i, n = len(values)
         Py_ssize_t idx
         int ret = 0
         float64_t val
         khiter_t k
-        npy_uint64 count = 0
+        np.uint64_t count = 0
         bint seen_na = 0
         kh_float64_t *table
 
@@ -550,14 +463,14 @@ cdef count_unique_float64(ndarray[float64_t] values):
 
     return count
 
-cdef count_unique_int64(ndarray[int64_t] values):
+cdef count_unique_int64(np.ndarray[int64_t] values):
     cdef:
         Py_ssize_t i, n = len(values)
         Py_ssize_t idx
         int ret = 0
         int64_t val
         khiter_t k
-        npy_uint64 count = 0
+        np.uint64_t count = 0
         kh_int64_t *table
 
     table = kh_init_int64()
@@ -575,14 +488,14 @@ cdef count_unique_int64(ndarray[int64_t] values):
 
     return count
 
-cdef count_unique_int32(ndarray[int32_t] values):
+cdef count_unique_int32(np.ndarray[int32_t] values):
     cdef:
         Py_ssize_t i, n = len(values)
         Py_ssize_t idx
         int ret = 0
         int32_t val
         khiter_t k
-        npy_uint64 count = 0
+        np.uint64_t count = 0
         kh_int32_t *table
 
     table = kh_init_int32()
@@ -610,12 +523,13 @@ cpdef agg_float64(carray ca_input, carray ca_factor,
         Py_ssize_t factor_chunk_nr, factor_chunk_len, factor_chunk_row
         Py_ssize_t current_index, i, j, end_counts, start_counts, factor_total_chunks, leftover_elements
 
-        ndarray[npy_float64] in_buffer
-        ndarray[npy_int64] factor_buffer
-        ndarray[npy_float64] out_buffer
-        ndarray[npy_float64] last_values
+        np.ndarray[np.float64_t] in_buffer
+        np.ndarray[np.int64_t] factor_buffer
+        np.ndarray[np.float64_t] out_buffer
 
-        npy_float64 v
+        np.ndarray[np.float64_t] last_values
+
+        np.float64_t v
         bint count_distinct_started = 0
         carray num_uniques
 
@@ -650,7 +564,13 @@ cpdef agg_float64(carray ca_input, carray ca_factor,
     else:
         factor_buffer = ca_factor.leftover_array
     factor_chunk_row = 0
-    out_buffer = np.zeros(nr_groups, dtype='float64')
+    # if we're calculating a mean, maintain a buffer tracking the
+    # the size of each group
+    if agg_method == _MEAN:
+        out_buffer = np.zeros(nr_groups, dtype='float64')
+        count_buffer = np.zeros(nr_groups, dtype='int64')
+    else:
+        out_buffer = np.zeros(nr_groups, dtype='float64')
 
     for input_chunk_nr in range(ca_input.nchunks):
         # fill input buffer
@@ -678,6 +598,11 @@ cpdef agg_float64(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -726,6 +651,11 @@ cpdef agg_float64(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -763,12 +693,13 @@ cpdef agg_int32(carray ca_input, carray ca_factor,
         Py_ssize_t factor_chunk_nr, factor_chunk_len, factor_chunk_row
         Py_ssize_t current_index, i, j, end_counts, start_counts, factor_total_chunks, leftover_elements
 
-        ndarray[npy_int32] in_buffer
-        ndarray[npy_int64] factor_buffer
-        ndarray[npy_int32] out_buffer
-        ndarray[npy_int32] last_values
+        np.ndarray[np.int32_t] in_buffer
+        np.ndarray[np.int64_t] factor_buffer
+        np.ndarray[np.int32_t] out_buffer
 
-        npy_int32 v
+        np.ndarray[np.int32_t] last_values
+
+        np.int32_t v
         bint count_distinct_started = 0
         carray num_uniques
 
@@ -803,7 +734,13 @@ cpdef agg_int32(carray ca_input, carray ca_factor,
     else:
         factor_buffer = ca_factor.leftover_array
     factor_chunk_row = 0
-    out_buffer = np.zeros(nr_groups, dtype='int32')
+    # if we're calculating a mean, maintain a buffer tracking the
+    # the size of each group
+    if agg_method == _MEAN:
+        out_buffer = np.zeros(nr_groups, dtype='float64')
+        count_buffer = np.zeros(nr_groups, dtype='int64')
+    else:
+        out_buffer = np.zeros(nr_groups, dtype='int32')
 
     for input_chunk_nr in range(ca_input.nchunks):
         # fill input buffer
@@ -831,6 +768,11 @@ cpdef agg_int32(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -878,6 +820,11 @@ cpdef agg_int32(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -914,12 +861,13 @@ cpdef agg_int64(carray ca_input, carray ca_factor,
         Py_ssize_t factor_chunk_nr, factor_chunk_len, factor_chunk_row
         Py_ssize_t current_index, i, j, end_counts, start_counts, factor_total_chunks, leftover_elements
 
-        ndarray[npy_int64] in_buffer
-        ndarray[npy_int64] factor_buffer
-        ndarray[npy_int64] out_buffer
-        ndarray[npy_int64] last_values
+        np.ndarray[np.int64_t] in_buffer
+        np.ndarray[np.int64_t] factor_buffer
+        np.ndarray[np.int64_t] out_buffer
 
-        npy_int64 v
+        np.ndarray[np.int64_t] last_values
+
+        np.int64_t v
         bint count_distinct_started = 0
         carray num_uniques
 
@@ -954,7 +902,13 @@ cpdef agg_int64(carray ca_input, carray ca_factor,
     else:
         factor_buffer = ca_factor.leftover_array
     factor_chunk_row = 0
-    out_buffer = np.zeros(nr_groups, dtype='int64')
+    # if we're calculating a mean, maintain a buffer tracking the
+    # the size of each group
+    if agg_method == _MEAN:
+        out_buffer = np.zeros(nr_groups, dtype='float64')
+        count_buffer = np.zeros(nr_groups, dtype='int64')
+    else:
+        out_buffer = np.zeros(nr_groups, dtype='int64')
 
     for input_chunk_nr in range(ca_input.nchunks):
         # fill input buffer
@@ -982,6 +936,11 @@ cpdef agg_int64(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -1029,6 +988,11 @@ cpdef agg_int64(carray ca_input, carray ca_factor,
             if current_index != skip_key:
                 if agg_method == _SUM:
                     out_buffer[current_index] += in_buffer[i]
+                elif agg_method == _MEAN:
+                    # method from Knuth
+                    count_buffer[current_index] += 1
+                    delta = in_buffer[i] - out_buffer[current_index]
+                    out_buffer[current_index] += delta / count_buffer[current_index]
                 elif agg_method == _COUNT:
                     out_buffer[current_index] += 1
                 elif agg_method == _COUNT_NA:
@@ -1064,9 +1028,9 @@ cpdef groupby_value(carray ca_input, carray ca_factor, Py_ssize_t nr_groups, Py_
         Py_ssize_t factor_chunk_nr, factor_chunk_len, factor_chunk_row
         Py_ssize_t current_index, i, factor_total_chunks, leftover_elements
 
-        ndarray in_buffer
-        ndarray[npy_int64] factor_buffer
-        ndarray out_buffer
+        np.ndarray in_buffer
+        np.ndarray[np.int64_t] factor_buffer
+        np.ndarray out_buffer
 
     count = 0
     ret = 0
@@ -1156,16 +1120,16 @@ cpdef is_in_ordered_subgroups(carray groups_col, carray bool_arr=None,
     :return: bool array marking the whole group as True if item found
     """
     cdef:
-        npy_int64 previous_item
-        npy_int64 actual_item
+        np.int64_t previous_item
+        np.int64_t actual_item
         Py_ssize_t blen
         Py_ssize_t len_subgroup = 0
         Py_ssize_t max_len_subgroup
         Py_ssize_t n
-        npy_bool is_in = False
+        np.npy_bool is_in = False
         carray ret
-        ndarray x, x_ones, x_zeros
-        ndarray bl_basket, bl_bool_arr
+        np.ndarray x, x_ones, x_zeros
+        np.ndarray bl_basket, bl_bool_arr
 
     max_len_subgroup = _max_len_subgroup
     ret = bz.zeros(0, dtype='bool', expectedlen=groups_col.len)
@@ -1221,7 +1185,7 @@ cpdef is_in_ordered_subgroups(carray groups_col, carray bool_arr=None,
 # Temporary Section
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef carray_is_in(carray col, set value_set, ndarray boolarr, bint reverse):
+cpdef carray_is_in(carray col, set value_set, np.ndarray boolarr, bint reverse):
     """
     TEMPORARY WORKAROUND till numexpr support in list operations
 

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -781,7 +781,7 @@ class TestCtable():
 
     def test_groupby_15(self):
         """
-        test_groupby_14: Groupby type 'std'
+        test_groupby_15: Groupby type 'std'
         """
         random.seed(1)
 

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -129,6 +129,7 @@ class TestCtable():
 
         groupby_cols = ['f0']
         groupby_lambda = lambda x: x[0]
+        # no operation is specified in `agg_list`, so `sum` is used by default.
         agg_list = ['f4', 'f5', 'f6']
         num_rows = 2000
 
@@ -165,6 +166,7 @@ class TestCtable():
 
         groupby_cols = ['f0', 'f1', 'f2']
         groupby_lambda = lambda x: [x[0], x[1], x[2]]
+        # no operation is specified in `agg_list`, so `sum` is used by default.
         agg_list = ['f4', 'f5', 'f6']
         num_rows = 2000
 
@@ -778,7 +780,7 @@ class TestCtable():
         # remove the first (text) element for floating point comparison
         result = [list(x[1:]) for x in result_bcolz]
 
-        assert_allclose(result, ref, rtol=1e-04)
+        assert_allclose(result, ref, rtol=1e-10)
 
     def _assert_list_equal(self, a, b):
         assert_list_equal(a, b)

--- a/setup.py
+++ b/setup.py
@@ -94,25 +94,13 @@ else:
 ########### Project specific command line options ###########
 
 class bquery_build_ext(build_ext):
-    user_options = build_ext.user_options + \
-        [
-        ('from-templates', None,
-         "rebuild project from code generation templates"),
-        ]
+    user_options = build_ext.user_options
 
     def initialize_options(self):
         self.from_templates = False
         build_ext.initialize_options(self)
 
     def run(self):
-        if self.from_templates:
-            try:
-                import jinja2
-            except:
-                exit_with_error(
-                    "You need the python package jinja2 to rebuild the " + \
-                    "extension from the templates")
-            exec(open("bquery/templates/run_templates.py").read())
 
         build_ext.run(self)
 


### PR DESCRIPTION
This does more than the title implies. In addition to implementing new operations for `mean` and `std` it also converts the extension to use fused types (removing the dependency on `jinja` and the need for an extra step in compilation). 

I thought long and hard about this, and decided it was the easiest way to allow separation of input and output column data types without significantly increasing the complexity of the code (especially on the python side). One remaining source of complexity with the fused type implementation is around the khash library. I haven't yet found a good clean way to reduce the code duplication here. This is something we should continue to investigate (possibly when fused types become accessible as attributes to extension types).

Performance also still needs to be tested to ensure it remains comparable.