### PR TITLE
Group index

### DIFF
--- a/bquery/benchmarks/taxi/Taxi Set.ipynb
+++ b/bquery/benchmarks/taxi/Taxi Set.ipynb
@@ -166,13 +166,13 @@
      "text": [
       "\n",
       "\n",
-      "CT payment_type nr_rides sum, single process:   7.4143 sec\n",
+      "CT payment_type nr_rides sum, single process:   7.7889 sec\n",
       "\n",
       "\n",
-      "CT yearmonth nr_rides sum, single process:   6.539 sec\n",
+      "CT yearmonth nr_rides sum, single process:   6.0658 sec\n",
       "\n",
       "\n",
-      "CT yearmonth + payment_type nr_rides sum, single process:   19.4206 sec\n"
+      "CT yearmonth + payment_type nr_rides sum, single process:   19.9401 sec\n"
      ]
     }
    ],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -207,13 +207,13 @@
      "text": [
       "\n",
       "\n",
-      "CT payment_type nr_rides sum, 8 processors:   2.1857 sec\n",
+      "CT payment_type nr_rides sum, 8 processors:   2.1193 sec\n",
       "\n",
       "\n",
-      "CT yearmonth nr_rides sum, 8 processors:   2.0831 sec\n",
+      "CT yearmonth nr_rides sum, 8 processors:   1.838 sec\n",
       "\n",
       "\n",
-      "CT yearmonth + payment_type nr_rides sum, 8 processors:   5.4554 sec\n"
+      "CT yearmonth + payment_type nr_rides sum, 8 processors:   5.3056 sec\n"
      ]
     }
    ],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -248,13 +248,13 @@
      "text": [
       "\n",
       "\n",
-      "CT payment_type all measure sum, single process:   28.1774 sec\n",
+      "CT payment_type all measure sum, single process:   25.6572 sec\n",
       "\n",
       "\n",
-      "CT yearmonth all measure sum, single process:   20.2913 sec\n",
+      "CT yearmonth all measure sum, single process:   17.6487 sec\n",
       "\n",
       "\n",
-      "CT yearmonth + payment_type all measure sum, single process:   34.6681 sec\n"
+      "CT yearmonth + payment_type all measure sum, single process:   33.237 sec\n"
      ]
     }
    ],
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -289,13 +289,13 @@
      "text": [
       "\n",
       "\n",
-      "CT payment_type all measure sum, 8 processors:   8.7609 sec\n",
+      "CT payment_type all measure sum, 8 processors:   7.7358 sec\n",
       "\n",
       "\n",
-      "CT yearmonth  all measure sum, 8 processors:   6.0413 sec\n",
+      "CT yearmonth  all measure sum, 8 processors:   5.2753 sec\n",
       "\n",
       "\n",
-      "CT yearmonth + payment_type  all measure sum, 8 processors:   9.6938 sec\n"
+      "CT yearmonth + payment_type  all measure sum, 8 processors:   9.2953 sec\n"
      ]
     }
    ],

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -17,7 +17,7 @@ from nose.tools import assert_list_equal
 import bquery
 
 
-`class TestCtable(object):
+class TestCtable(object):
     @contextmanager
     def on_disk_data_cleaner(self, data):
         self.rootdir = tempfile.mkdtemp(prefix='bcolz-')

--- a/bquery/tests/test_ctable.py
+++ b/bquery/tests/test_ctable.py
@@ -17,7 +17,7 @@ from nose.tools import assert_list_equal
 import bquery
 
 
-class TestCtable():
+`class TestCtable(object):
     @contextmanager
     def on_disk_data_cleaner(self, data):
         self.rootdir = tempfile.mkdtemp(prefix='bcolz-')


### PR DESCRIPTION
Changed the group index method to the same method as used by Python's dict

This will increase the speed for aggregations over larger multi-column aggregations. For small multi-column aggregations it's still slightly faster.
There are two future enhancements still:
- Make creating the group index carray based instead of numpy (which will greatly improve memory usage)
- Cache multi-column unique combinations, which will greatly enhance the speed
