### PR TITLE
Group index mem opt

### DIFF
--- a/bquery/benchmarks/taxi/Taxi Set.ipynb
+++ b/bquery/benchmarks/taxi/Taxi Set.ipynb
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -165,17 +165,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "\n",
-      "CT payment_type nr_rides sum, single process:  \n",
-      "(6.8386, 'sec')\n",
-      "\n",
-      "\n",
-      "CT yearmonth nr_rides sum, single process:  \n",
-      "(5.6374, 'sec')\n",
-      "\n",
-      "\n",
-      "CT yearmonth + payment_type nr_rides sum, single process:  \n",
-      "(11.5002, 'sec')\n"
+      "\n"
      ]
     }
    ],

--- a/bquery/benchmarks/taxi/Taxi Set.ipynb
+++ b/bquery/benchmarks/taxi/Taxi Set.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -167,15 +167,15 @@
       "\n",
       "\n",
       "CT payment_type nr_rides sum, single process:  \n",
-      "8.1386 sec\n",
+      "(6.8386, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth nr_rides sum, single process:  \n",
-      "6.4309 sec\n",
+      "(5.6374, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth + payment_type nr_rides sum, single process:  \n",
-      "19.4896 sec\n"
+      "(11.5002, 'sec')\n"
      ]
     }
    ],
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -211,15 +211,15 @@
       "\n",
       "\n",
       "CT payment_type nr_rides sum, 8 processors:  \n",
-      "2.5132 sec\n",
+      "(2.5027, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth nr_rides sum, 8 processors:  \n",
-      "2.3545 sec\n",
+      "(2.0151, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth + payment_type nr_rides sum, 8 processors:  \n",
-      "6.3254 sec\n"
+      "(3.5422, 'sec')\n"
      ]
     }
    ],
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -255,15 +255,15 @@
       "\n",
       "\n",
       "CT payment_type all measure sum, single process:  \n",
-      "29.9549 sec\n",
+      "(26.9181, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth all measure sum, single process:  \n",
-      "19.7059 sec\n",
+      "(17.2693, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth + payment_type all measure sum, single process:  \n",
-      "34.5697 sec\n"
+      "(25.5354, 'sec')\n"
      ]
     }
    ],
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -299,15 +299,15 @@
       "\n",
       "\n",
       "CT payment_type all measure sum, 8 processors:  \n",
-      "8.7642 sec\n",
+      "(7.7475, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth  all measure sum, 8 processors:  \n",
-      "5.984 sec\n",
+      "(5.0945, 'sec')\n",
       "\n",
       "\n",
       "CT yearmonth + payment_type  all measure sum, 8 processors:  \n",
-      "10.1257 sec\n"
+      "(7.9836, 'sec')\n"
      ]
     }
    ],
@@ -334,21 +334,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1+"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11+"
   }
  },
  "nbformat": 4,

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -54,7 +54,8 @@ class ctable(bcolz.ctable):
         cache_valid = False
 
         if self.rootdir:
-            col_values_file_check = self.create_group_base_name(col_list) + '.values/__attrs__'
+            col_values_file_check = os.path.join(self.rootdir, self.create_group_base_name(col_list)) + \
+                                    '.values/__attrs__'
 
             exists_group_index = os.path.exists(col_values_file_check)
             missing_col_check = [1 for col in col_list if not os.path.exists(self[col].rootdir + '/__attrs__')]
@@ -88,6 +89,11 @@ class ctable(bcolz.ctable):
 
         if not isinstance(col_list, list):
             col_list = [col_list]
+
+        if refresh:
+            kill_list = [x for x in os.listdir(self.rootdir) if '.factor' in x or '.values' in x]
+            for kill_dir in kill_list:
+                shutil.rmtree(os.path.join(self.rootdir, kill_dir))
 
         for col in col_list:
 
@@ -323,7 +329,7 @@ class ctable(bcolz.ctable):
 
     def create_group_column_factor(self, factor_list, groupby_cols, cache=False):
         if cache:
-            col_rootdir = self.create_group_base_name(groupby_cols)
+            col_rootdir = os.path.join(self.rootdir, self.create_group_base_name(groupby_cols))
             col_factor_rootdir = col_rootdir + '.factor'
             col_values_rootdir = col_rootdir + '.values'
             input_rootdir = tempfile.mkdtemp(prefix='bcolz-')
@@ -397,7 +403,7 @@ class ctable(bcolz.ctable):
             # first combine the factorized columns to single values
             if self.group_cache_valid(col_list=groupby_cols):
                 # there is a group cache that we can use
-                col_rootdir = self.create_group_base_name(groupby_cols)
+                col_rootdir = os.path.join(self.rootdir, self.create_group_base_name(groupby_cols))
                 col_factor_rootdir = col_rootdir + '.factor'
                 carray_factor = bcolz.carray(rootdir=col_factor_rootdir)
                 col_values_rootdir = col_rootdir + '.values'

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -347,15 +347,14 @@ class ctable(bcolz.ctable):
             col_factor_rootdir_tmp = None
             col_values_rootdir_tmp = None
 
-        group_array = bcolz.zeros(0, dtype=np.int64, expectedlen=len(self), rootdir=input_rootdir)
+        group_array = bcolz.zeros(0, dtype=np.int64, expectedlen=len(self), rootdir=input_rootdir, mode='w')
         factor_table = bcolz.ctable(factor_list, names=groupby_cols)
         ctable_iter = factor_table.iter(outcols=groupby_cols, out_flavor=tuple)
         ctable_ext.create_group_index(ctable_iter, len(groupby_cols), group_array)
 
         # now factorize the results
         carray_factor = \
-            bcolz.carray([], dtype='int64', expectedlen=self.size,
-                         rootdir=col_factor_rootdir_tmp)
+            bcolz.carray([], dtype='int64', expectedlen=self.size, rootdir=col_factor_rootdir_tmp, mode='w')
         carray_factor, values = ctable_ext.factorize(group_array, labels=carray_factor)
         if cache:
             carray_factor.flush()
@@ -364,7 +363,7 @@ class ctable(bcolz.ctable):
             carray_factor = bcolz.carray(rootdir=col_factor_rootdir, mode='r')
 
         carray_values = \
-            bcolz.carray(np.fromiter(values.values(), dtype=np.int64), rootdir=col_values_rootdir_tmp)
+            bcolz.carray(np.fromiter(values.values(), dtype=np.int64), rootdir=col_values_rootdir_tmp, mode='w')
         if cache:
             carray_values.flush()
             shutil.rmtree(col_values_rootdir, ignore_errors=True)

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -7,7 +7,6 @@ import shutil
 # external imports
 import numpy as np
 import bcolz
-import os
 from bquery.ctable_ext import \
     SUM, COUNT, COUNT_NA, COUNT_DISTINCT, SORTED_COUNT_DISTINCT, \
     MEAN, STDEV
@@ -317,6 +316,17 @@ class ctable(bcolz.ctable):
 
     @staticmethod
     def _int_array_hash(input_list):
+        """
+        A function to calculate a hash value of multiple integer values, not used at the moment
+
+        Parameters
+        ----------
+        input_list
+
+        Returns
+        -------
+
+        """
 
         list_len = len(input_list)
         arr_len = len(input_list[0])
@@ -335,6 +345,19 @@ class ctable(bcolz.ctable):
         return result_carray
 
     def create_group_column_factor(self, factor_list, groupby_cols, cache=False):
+        """
+        Create a unique, factorized column out of a lost of individual columns
+
+        Parameters
+        ----------
+        factor_list
+        groupby_cols
+        cache
+
+        Returns
+        -------
+
+        """
         if cache:
             col_rootdir = os.path.join(self.rootdir, self.create_group_base_name(groupby_cols))
             col_factor_rootdir = col_rootdir + '.factor'

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -108,13 +108,12 @@ class ctable(bcolz.ctable):
                 # create factor
                 carray_factor = \
                     bcolz.carray([], dtype='int64', expectedlen=self.size,
-                                 rootdir=col_factor_rootdir, mode='w')
+                                 rootdir=col_factor_rootdir_tmp, mode='w')
                 _, values = \
                     ctable_ext.factorize(self[col], labels=carray_factor)
                 carray_factor.flush()
                 shutil.rmtree(col_factor_rootdir, ignore_errors=True)
                 shutil.move(col_factor_rootdir_tmp, col_factor_rootdir)
-                carray_factor.rootdir = col_factor_rootdir
 
                 # create values
                 carray_values = \
@@ -123,7 +122,6 @@ class ctable(bcolz.ctable):
                 carray_values.flush()
                 shutil.rmtree(col_values_rootdir, ignore_errors=True)
                 shutil.move(col_values_rootdir_tmp, col_values_rootdir)
-                carray_values.rootdir = col_values_rootdir
 
     def unique(self, col_or_col_list):
         """
@@ -363,7 +361,7 @@ class ctable(bcolz.ctable):
             carray_factor.flush()
             shutil.rmtree(col_factor_rootdir, ignore_errors=True)
             shutil.move(col_factor_rootdir_tmp, col_factor_rootdir)
-            carray_factor.rootdir = col_factor_rootdir
+            carray_factor = bcolz.carray(rootdir=col_factor_rootdir, mode='r')
 
         carray_values = \
             bcolz.carray(np.fromiter(values.values(), dtype=np.int64), rootdir=col_values_rootdir_tmp)
@@ -371,7 +369,7 @@ class ctable(bcolz.ctable):
             carray_values.flush()
             shutil.rmtree(col_values_rootdir, ignore_errors=True)
             shutil.move(col_values_rootdir_tmp, col_values_rootdir)
-            carray_values.rootdir = col_values_rootdir
+            carray_values = bcolz.carray(rootdir=col_values_rootdir, mode='r')
 
         del group_array
         if cache:

--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -1,5 +1,8 @@
 # internal imports
 from bquery import ctable_ext
+import tempfile
+import os
+import shutil
 
 # external imports
 import numpy as np
@@ -11,6 +14,18 @@ from bquery.ctable_ext import \
 
 
 class ctable(bcolz.ctable):
+    def __init__(self, *args, **kwargs):
+        super(ctable, self).__init__(*args, **kwargs)
+        if self.rootdir and kwargs.get('auto_cache') is not False:
+            self.auto_cache = True
+        else:
+            self.auto_cache = False
+
+    @staticmethod
+    def create_group_base_name(col_list):
+        group_name = '_'.join(sorted(col_list))
+        return group_name
+
     def cache_valid(self, col):
         """
         Checks whether the column has a factorization that exists and is not older than the source
@@ -18,19 +33,39 @@ class ctable(bcolz.ctable):
         :param col:
         :return:
         """
+        cache_valid = False
+
         if self.rootdir:
             col_org_file_check = self[col].rootdir + '/__attrs__'
             col_values_file_check = self[col].rootdir + '.values/__attrs__'
 
-            if not os.path.exists(col_org_file_check):
-                raise KeyError(str(col) + ' does not exist')
+            if os.path.exists(col_org_file_check) and os.path.exists(col_values_file_check):
+                cache_valid = os.path.getctime(col_org_file_check) < os.path.getctime(col_values_file_check)
 
-            if os.path.exists(col_values_file_check):
-                return os.path.getctime(col_org_file_check) < os.path.getctime(col_values_file_check)
-            else:
-                return False
-        else:
-            return False
+        return cache_valid
+
+    def group_cache_valid(self, col_list):
+        """
+        Checks whether the column has a factorization that exists and is not older than the source
+
+        :param col:
+        :return:
+        """
+        cache_valid = False
+
+        if self.rootdir:
+            col_values_file_check = self.create_group_base_name(col_list) + '.values/__attrs__'
+
+            exists_group_index = os.path.exists(col_values_file_check)
+            missing_col_check = [1 for col in col_list if not os.path.exists(self[col].rootdir + '/__attrs__')]
+
+            if exists_group_index and not missing_col_check:
+                group_col_timestamp = os.path.getctime(col_values_file_check)
+                col_timestamp_list = [os.path.getctime(self[col].rootdir + '/__attrs__') for col in col_list]
+                cache_valid = max(col_timestamp_list) < group_col_timestamp
+
+        return cache_valid
+
 
     def cache_factor(self, col_list, refresh=False):
         """
@@ -74,6 +109,7 @@ class ctable(bcolz.ctable):
                                  rootdir=col_values_rootdir, mode='w')
                 carray_values.flush()
 
+
     def unique(self, col_or_col_list):
         """
         Return a list of unique values of a column or a list of lists of column list
@@ -93,7 +129,11 @@ class ctable(bcolz.ctable):
 
         for col in col_list:
 
-            if self.cache_valid(col):
+            if self.auto_cache or self.cache_valid(col):
+                # create factorization cache
+                if not self.cache_valid(col):
+                    self.cache_factor([col])
+
                 # retrieve values from existing disk-based factorization
                 col_values_rootdir = self[col].rootdir + '.values'
                 carray_values = bcolz.carray(rootdir=col_values_rootdir, mode='r')
@@ -111,7 +151,7 @@ class ctable(bcolz.ctable):
         return output
 
     def aggregate_groups(self, ct_agg, nr_groups, skip_key,
-                         factor_carray, groupby_cols, output_agg_ops,
+                         carray_factor, groupby_cols, output_agg_ops,
                          dtype_dict, bool_arr=None):
         '''Perform aggregation and place the result in the given ctable.
 
@@ -119,7 +159,7 @@ class ctable(bcolz.ctable):
             ct_agg (ctable): the table to hold the aggregation
             nr_groups (int): the number of groups (number of rows in output table)
             skip_key (int): index of the output row to remove from results (used for filtering)
-            factor_carray: the carray for each row in the table a reference to the the unique group index
+            carray_factor: the carray for each row in the table a reference to the the unique group index
             groupby_cols: the list of 'dimension' columns that are used to perform the groupby over
             output_agg_ops (list): list of tuples of the form: (input_col, agg_op)
                     input_col (string): name of the column to act on
@@ -131,7 +171,7 @@ class ctable(bcolz.ctable):
         # this creates the groupby columns
         for col in groupby_cols:
 
-            result_array = ctable_ext.groupby_value(self[col], factor_carray,
+            result_array = ctable_ext.groupby_value(self[col], carray_factor,
                                                     nr_groups, skip_key)
 
             if bool_arr is not None:
@@ -150,7 +190,7 @@ class ctable(bcolz.ctable):
             output_buffer = np.zeros(nr_groups, dtype=output_col_dtype)
 
             try:
-                ctable_ext.aggregate(input_col, factor_carray, nr_groups,
+                ctable_ext.aggregate(input_col, carray_factor, nr_groups,
                                      skip_key, input_buffer, output_buffer,
                                      agg_op)
             except TypeError:
@@ -201,11 +241,8 @@ class ctable(bcolz.ctable):
             raise AttributeError('One or more aggregation operations '
                                  'need to be defined')
 
-        factor_list, values_list = self.factorize_groupby_cols(groupby_cols)
-
-        factor_carray, nr_groups, skip_key = \
-            self.make_group_index(factor_list, values_list, groupby_cols,
-                                  len(self), bool_arr)
+        carray_factor, nr_groups, skip_key = \
+            self.make_group_index(groupby_cols, bool_arr)
 
         # check if the bool_arr actually filters
         if bool_arr is not None and np.all(bool_arr):
@@ -221,7 +258,7 @@ class ctable(bcolz.ctable):
 
         # perform aggregation
         self.aggregate_groups(ct_agg, nr_groups, skip_key,
-                              factor_carray, groupby_cols,
+                              carray_factor, groupby_cols,
                               agg_ops, dtype_dict,
                               bool_arr=bool_arr)
 
@@ -230,8 +267,10 @@ class ctable(bcolz.ctable):
     # groupby helper functions
     def factorize_groupby_cols(self, groupby_cols):
         """
+        factorizes all columns that are used in the groupby
+        it will use cache carrays if available
+        if not yet auto_cache is valid, it will create cache carrays
 
-        :type self: ctable
         """
         # first check if the factorized arrays already exist
         # unless we need to refresh the cache
@@ -241,21 +280,25 @@ class ctable(bcolz.ctable):
         # factorize the groupby columns
         for col in groupby_cols:
 
-            if self.cache_valid(col):
+            if self.auto_cache or self.cache_valid(col):
+                # create factorization cache if needed
+                if not self.cache_valid(col):
+                    self.cache_factor([col])
+
                 col_rootdir = self[col].rootdir
                 col_factor_rootdir = col_rootdir + '.factor'
                 col_values_rootdir = col_rootdir + '.values'
-                col_factor_carray = \
+                col_carray_factor = \
                     bcolz.carray(rootdir=col_factor_rootdir, mode='r')
-                col_values_carray = \
+                col_carray_values = \
                     bcolz.carray(rootdir=col_values_rootdir, mode='r')
             else:
-                col_factor_carray, values = ctable_ext.factorize(self[col])
-                col_values_carray = \
+                col_carray_factor, values = ctable_ext.factorize(self[col])
+                col_carray_values = \
                     bcolz.carray(np.fromiter(values.values(), dtype=self[col].dtype))
 
-            factor_list.append(col_factor_carray)
-            values_list.append(col_values_carray)
+            factor_list.append(col_carray_factor)
+            values_list.append(col_carray_values)
 
         return factor_list, values_list
 
@@ -278,8 +321,48 @@ class ctable(bcolz.ctable):
         del value_arr
         return result_carray
 
-    def make_group_index(self, factor_list, values_list, groupby_cols,
-                         array_length, bool_arr):
+    def create_group_column_factor(self, factor_list, groupby_cols, cache=False):
+        if cache:
+            col_rootdir = self.create_group_base_name(groupby_cols)
+            col_factor_rootdir = col_rootdir + '.factor'
+            col_values_rootdir = col_rootdir + '.values'
+            input_rootdir = tempfile.mkdtemp(prefix='bcolz-')
+            # clean directories
+            if os.path.exists(col_factor_rootdir):
+                shutil.rmtree(col_factor_rootdir)
+            if os.path.exists(col_values_rootdir):
+                shutil.rmtree(col_values_rootdir)
+            if os.path.exists(input_rootdir):
+                shutil.rmtree(input_rootdir)
+        else:
+            col_factor_rootdir = None
+            col_values_rootdir = None
+
+        group_array = bcolz.zeros(0, dtype=np.int64, expectedlen=len(self), rootdir=input_rootdir)
+        factor_table = bcolz.ctable(factor_list, names=groupby_cols)
+        ctable_iter = factor_table.iter(outcols=groupby_cols, out_flavor=tuple)
+        ctable_ext.create_group_index(ctable_iter, len(groupby_cols), group_array)
+        
+        # now factorize the results
+        carray_factor = \
+            bcolz.carray([], dtype='int64', expectedlen=self.size,
+                         rootdir=col_factor_rootdir)
+        carray_factor, values = ctable_ext.factorize(group_array, labels=carray_factor)
+        if cache:
+            carray_factor.flush()
+
+        carray_values = \
+            bcolz.carray(np.fromiter(values.values(), dtype=np.int64), rootdir=col_values_rootdir)
+        if cache:
+            carray_values.flush()
+        
+        if cache:
+            # clean up the temporary file
+            shutil.rmtree(input_rootdir)
+
+        return carray_factor, carray_values
+
+    def make_group_index(self, groupby_cols, bool_arr):
         '''Create unique groups for groupby loop
 
             Args:
@@ -290,55 +373,73 @@ class ctable(bcolz.ctable):
                 bool_arr:
 
             Returns:
-                carray: (factor_carray)
+                carray: (carray_factor)
                 int: (nr_groups) the number of resulting groups
                 int: (skip_key)
         '''
+        array_length = len(self)
+        factor_list, values_list = self.factorize_groupby_cols(groupby_cols)
 
         # create unique groups for groupby loop
         if len(factor_list) == 0:
             # no columns to groupby over, so directly aggregate the measure
             # columns to 1 total (index 0/zero)
-            factor_carray = bcolz.zeros(array_length, dtype='int64')
-            values = ['Total']
+            carray_factor = bcolz.zeros(array_length, dtype='int64')
+            carray_values = ['Total']
         elif len(factor_list) == 1:
             # single column groupby, the groupby output column
             # here is 1:1 to the values
-            factor_carray = factor_list[0]
-            values = values_list[0]
+            carray_factor = factor_list[0]
+            carray_values = values_list[0]
         else:
             # multi column groupby
             # todo: this might also be cached in the future
-            # todo: move out-of-core instead of a numpy array
             # first combine the factorized columns to single values
-            group_array = self._int_array_hash(factor_list)
-            factor_carray, values = ctable_ext.factorize(group_array)
+            if self.group_cache_valid(col_list=groupby_cols):
+                # there is a group cache that we can use
+                col_rootdir = self.create_group_base_name(groupby_cols)
+                col_factor_rootdir = col_rootdir + '.factor'
+                carray_factor = bcolz.carray(rootdir=col_factor_rootdir)
+                col_values_rootdir = col_rootdir + '.values'
+                carray_values = bcolz.carray(rootdir=col_values_rootdir)
+            elif self.auto_cache:
+                # create a new group cache
+                carray_factor, carray_values = \
+                    self.create_group_column_factor(factor_list, groupby_cols, cache=True)
+            else:
+                # no cached group indexes
+                # create a new group cache
+                carray_factor, carray_values = \
+                    self.create_group_column_factor(factor_list, groupby_cols, cache=False)
 
+        nr_groups = len(carray_values)
         skip_key = None
 
         if bool_arr is not None:
             # make all non relevant combinations -1
-            factor_carray = bcolz.eval(
+            carray_factor = bcolz.eval(
                 '(factor + 1) * bool - 1',
-                user_dict={'factor': factor_carray, 'bool': bool_arr})
+                user_dict={'factor': carray_factor, 'bool': bool_arr})
             # now check how many unique values there are left
-            factor_carray, values = ctable_ext.factorize(factor_carray)
+            carray_factor, values = ctable_ext.factorize(carray_factor)
             # values might contain one value too much (-1) (no direct lookup
             # possible because values is a reversed dict)
             filter_check = \
                 [key for key, value in values.items() if value == -1]
             if filter_check:
                 skip_key = filter_check[0]
+            # the new nr of groups depends on the outcome after filtering
+            nr_groups = len(values)
 
         # using nr_groups as a total length might be one one off due to the skip_key
         # (skipping a row in aggregation)
         # but that is okay normally
-        nr_groups = len(values)
+
         if skip_key is None:
             # if we shouldn't skip a row, set it at the first row after the total number of groups
             skip_key = nr_groups
 
-        return factor_carray, nr_groups, skip_key
+        return carray_factor, nr_groups, skip_key
 
     def create_agg_ctable(self, groupby_cols, agg_list, expectedlen, rootdir):
         '''Create a container for the output table, a dictionary describing it's

--- a/bquery/ctable_ext.pyx
+++ b/bquery/ctable_ext.pyx
@@ -838,7 +838,7 @@ cpdef is_in_ordered_subgroups(carray groups_col, carray bool_arr=None,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef apply_where_terms(list array_list, list op_list, list value_list, carray boolarr):
+cpdef apply_where_terms(ctable_iter, list op_list, list value_list, carray boolarr):
     """
     Update a boolean array with checks whether the values of a column (col) are in a set (value_set)
 
@@ -851,58 +851,27 @@ cpdef apply_where_terms(list array_list, list op_list, list value_list, carray b
     :return:
     """
     cdef:
-        chunk chunk_
-        carray current_carray
         Py_ssize_t total_len, out_index, in_index, chunk_len, out_check_pos, in_check_pos, leftover_elements
         np.ndarray[np.int8_t] out_buffer
-        np.ndarray[np.int64_t] current_buffer
-        list walk_array_list, cursor_list, check_pos_list, current_chunk_list
         set filter_set
         bint row_bool
         int filter_val, current_val, array_nr, op_id, current_chunk_nr
-
-    total_len = array_list[0].len
+        tuple row
 
     chunk_len = boolarr.chunklen
     out_check_pos = chunk_len - 1
-
     out_buffer = np.empty(chunk_len, dtype=np.int8)
-    chunk_list = []
-
-    current_chunk_list = [1] * len(array_list)
-    check_pos_list = []
-    walk_array_list = []
-
-    for array_nr, current_carray in enumerate(array_list):
-        chunk_len = current_carray.chunklen
-        check_pos_list.append(chunk_len - 1)
-        current_buffer = np.empty(chunk_len, dtype=np.int64)
-
-        if current_carray.nchunks > 0:
-            chunk_ = current_carray.chunks[0]
-            # decompress into in_buffer
-            chunk_._getitem(0, chunk_len, current_buffer.data)
-        else:
-            current_buffer = current_carray.leftover_array
-
-        walk_array_list.append(current_buffer)
-
     out_index = 0
-    cursor_list = [0 for current_carray in array_list]
 
-    for _ in range(total_len):
+    for row in ctable_iter:
         row_bool = True
 
-        for array_nr, op_id in enumerate(op_list):
+        for current_val, op_id, input_val in zip(row, op_list, value_list):
 
             if op_id in [3, 4]:
-                filter_set = value_list[array_nr]
+                filter_set = input_val
             else:
-                filter_val = value_list[array_nr]
-
-            current_buffer = walk_array_list[array_nr]
-            in_index = cursor_list[array_nr]
-            current_val = current_buffer[in_index]
+                filter_val = input_val
 
             # instructions sorted on frequency
             if op_id == 3:  # in
@@ -947,30 +916,6 @@ cpdef apply_where_terms(list array_list, list op_list, list value_list, carray b
             out_index = 0
         else:
             out_index += 1
-
-        # update walk list
-        for array_nr, in_check_pos in enumerate(check_pos_list):
-            in_index = cursor_list[array_nr]
-
-            if in_index == in_check_pos:
-                # retrieve new values
-                current_carray = array_list[array_nr]
-                chunk_len = current_carray.chunklen
-                current_buffer = walk_array_list[array_nr]
-                current_chunk_list[array_nr] += 1
-                current_chunk_nr = current_chunk_list[array_nr]
-
-                if current_carray.nchunks >= current_chunk_nr:
-                    chunk_ = current_carray.chunks[current_chunk_nr - 1]
-                    # decompress into in_buffer
-                    chunk_._getitem(0, chunk_len, current_buffer.data)
-                else:
-                    current_buffer = current_carray.leftover_array
-
-                walk_array_list[array_nr] = current_buffer
-                cursor_list[array_nr] = 0
-            else:
-                cursor_list[array_nr] = in_index + 1
 
     # write dangling last array if available
     if 0 < out_index < out_check_pos:


### PR DESCRIPTION
- Moved towards usage of tuples from bcolz iter where multiple columns where addressed at the same time
- Improved groupby memory utilization
- Introduced groupby factorization caching for on-disk ctables

