### PR TITLE
Remove unnecesary tmp dir removal

### DIFF
--- a/bquery/ctable.py
+++ b/bquery/ctable.py
@@ -151,8 +151,6 @@ class ctable(bcolz.ctable):
                 carray_values.flush()
                 rm_file_or_dir(col_values_rootdir, ignore_errors=True)
                 shutil.move(col_values_rootdir_tmp, col_values_rootdir)
-            else:
-                rm_file_or_dir(col_factor_rootdir_tmp, ignore_errors=True)
 
     def unique(self, col_or_col_list):
         """


### PR DESCRIPTION
Hi @CarstVaartjes! This patch should fix the error below:

~~~~
In [142]: ct.cache_factor([column_name], refresh=False)
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-142-a4a60c8761ad> in <module>()
----> 1 ct.cache_factor([column_name], refresh=False)

/srv/python/venv/local/lib/python2.7/site-packages/bquery/ctable.pyc in cache_factor(self, col_list, refresh)
    153                 shutil.move(col_values_rootdir_tmp, col_values_rootdir)
    154             else:
--> 155                 rm_file_or_dir(col_factor_rootdir_tmp, ignore_errors=True)
    156 
    157     def unique(self, col_or_col_list):

UnboundLocalError: local variable 'col_factor_rootdir_tmp' referenced before assignment
~~~~